### PR TITLE
修复写入乱码文件报错情况

### DIFF
--- a/BNetdisk.py
+++ b/BNetdisk.py
@@ -1,6 +1,5 @@
 import os
 
-
 def create_backup():
     # 获取用户输入的源目录和目标目录路径
     src_dir = input("请输入源目录的路径：")
@@ -16,7 +15,7 @@ def create_backup():
 
     # 尝试从文件中读取已备份的文件和目录
     try:
-        with open("backup_log.txt", "r", encoding="utf-8") as f:
+        with open('backup_log.txt', 'r', encoding='utf-8') as f:
             for line in f:
                 backed_up.add(line.strip())
     except FileNotFoundError:
@@ -46,8 +45,8 @@ def create_backup():
 
             dest_file = os.path.join(dest_path, filename)
             try:
-                with open(dest_file, "w", encoding="utf-8") as f:
-                    f.write(" " * 1024)  # 创建1KB大小的文件
+                with open(dest_file, 'w', encoding='utf-8') as f:
+                    f.write(' ' * 1024)  # 创建1KB大小的文件
                 # 记录这个文件已经被备份
                 backed_up.add(src_file)
                 num_backed_up += 1
@@ -56,12 +55,11 @@ def create_backup():
                 print(f"创建文件 {dest_file} 时出错: {e}")
 
     # 将已备份的文件和目录写入到文件中
-    with open("backup_log.txt", "w", encoding="utf-8") as f:
+    with open('backup_log.txt', 'w', encoding='utf-8') as f:
         for item in backed_up:
-            f.write(item + "\n")
+            f.write(item + '\n')
 
     print("备份完成！")
-
 
 # 使用方法
 create_backup()

--- a/BNetdisk.py
+++ b/BNetdisk.py
@@ -1,5 +1,6 @@
 import os
 
+
 def create_backup():
     # 获取用户输入的源目录和目标目录路径
     src_dir = input("请输入源目录的路径：")
@@ -15,7 +16,7 @@ def create_backup():
 
     # 尝试从文件中读取已备份的文件和目录
     try:
-        with open('backup_log.txt', 'r') as f:
+        with open("backup_log.txt", "r", encoding="utf-8") as f:
             for line in f:
                 backed_up.add(line.strip())
     except FileNotFoundError:
@@ -45,8 +46,8 @@ def create_backup():
 
             dest_file = os.path.join(dest_path, filename)
             try:
-                with open(dest_file, 'w') as f:
-                    f.write(' ' * 1024)  # 创建1KB大小的文件
+                with open(dest_file, "w", encoding="utf-8") as f:
+                    f.write(" " * 1024)  # 创建1KB大小的文件
                 # 记录这个文件已经被备份
                 backed_up.add(src_file)
                 num_backed_up += 1
@@ -55,11 +56,12 @@ def create_backup():
                 print(f"创建文件 {dest_file} 时出错: {e}")
 
     # 将已备份的文件和目录写入到文件中
-    with open('backup_log.txt', 'w') as f:
+    with open("backup_log.txt", "w", encoding="utf-8") as f:
         for item in backed_up:
-            f.write(item + '\n')
+            f.write(item + "\n")
 
     print("备份完成！")
+
 
 # 使用方法
 create_backup()


### PR DESCRIPTION
如果出现乱码文件，如：��Ĭ���� 写入日志会出现报错

```
Traceback (most recent call last):
  File "d:\BNetdisk.py\BNetdisk.py", line 65, in <module>
    create_backup()
  File "d:\BNetdisk.py\BNetdisk.py", line 60, in create_backup
    f.write(item + '\n')
```